### PR TITLE
Add /ecosystem folder and initial template for ecosystem calls

### DIFF
--- a/ecosystem/notes/YYYY-MM-DD-ecosystem-call.md
+++ b/ecosystem/notes/YYYY-MM-DD-ecosystem-call.md
@@ -1,0 +1,1 @@
+This is a placeholder for the first ecosystem call. Note that the naming convention for all notes should follow the `YYYY-MM-DD-ecosystem-call.md` convention.

--- a/ecosystem/templates/ecosystem-call-template.md
+++ b/ecosystem/templates/ecosystem-call-template.md
@@ -1,0 +1,36 @@
+# ツ Grin Ecosystem Call 📞 $DATE
+
+- **Moderator:** $MODERATOR
+- **Notetaker:** $NOTETAKER
+- **Attendees:**
+  - _attendee names..._
+
+## Moderator Checklist
+
+- [ ] Ensure the video link is working
+- [ ] Ensure there is a notetaker and live markdown-friendly notepad
+- [ ] Call for additional agenda items
+- [ ] Ask attendees to list their names (if they want name on the attendees list)
+
+## Presentation
+_Schedule presentation_
+- (<your_name>, <estimated length in mins>) <Title of your talk> 
+
+## Agenda
+_General discussion, ecosystem development, new products/releases, etc._
+<!-- use this format for all topics, demos, etc. that you add to the agenda: -->
+- (<your_name>, <estimated length in mins>) <Topic> 
+
+## Demos
+_Show the Grin community your latest work!_
+- (<your_name>, <estimated length in mins>) <Title of your demo> 
+
+## Help Wanted
+_Ask the community for help in areas where your project could use it (design, development, UX, connections, etc.)._
+
+## Open Questions & Issues with Grin
+_Ask questions and share issues you've experienced working with Grin; this becomes feedback for core protocol development._
+
+<!-- 
+After each call, it is the responsibility of the notetaker to save the last version of the notes in the https://github.com/mimblewimble/grin-pm/ecosystem/notes file, by opening a branch and submitting a PR. 
+-->


### PR DESCRIPTION
This PR adds an `/ecosystem` folder to the repo that will be used to track community calls relating to the evolution of new products and developments in the Grin ecosystem. In a nutshell: this is an experiment in creating a call for people building things on top of the core protocol.

cc: @lehnberg 

## Background
This PR is result of dialogue with @lehnberg and a few others in the product community regarding how we might prototype an open, community-based call that would be used to convene and coordinate people who are building products and experiences on top of Grin. This call is inspired by the [IPFS team calls](https://github.com/ipfs/team-mgmt) that started up when the protocol was more embryonic. 

## Intent / Purpose
Since most resources are going to core development at this point (as they should), the product makers are often left with answers that both start—and end—in: "read the docs" or "check out Gitter." I've seen this result in frustration, shared questions, and duplicate work. 

A regular, community call, focused on the rapidly growing product community, intends to be:
- a forum to convene Grin product/experience makers regularly
- a place to showcase what people are making in the Grin ecosystem
- a way to understand how the Grin ecosystem is developing (above the protocol) and how the needs evolve
- a place for the makers to ask for help (e.g.: I need developers, designers, connections, etc.)
- an on-ramp for outsiders to get involved in the Grin product ecosystem
- a place to gather functional feedback for the core protocol development tea

