### PR TITLE
add funding transparency logs

### DIFF
--- a/decision_log.md
+++ b/decision_log.md
@@ -5,25 +5,25 @@ This document tracks decisions made by the Grin project and points to documentat
 
 ## Decisions
 
-| Date | Decision | Reference |
-|:---|:---|:---|
-|20190219 | Release week for v1.0.2 | [Meeting Note](notes/20190219-meeting-development.md#decision-v102) |
-|20190212 | Firm to hire for security audit | [Meeting Note](notes/20190212-meeting-governance.md#decision-security-audit-firm) |
-|20190205 | Handling unsafe http transactions | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190205-meeting-development.md#decision-approach-for-http-transactions-in-grin-wallet) |
-|20190129 | StackExchange approach | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190129-meeting-governance.md#decision-stackexchange-approach) |
-|20190129 | Run https listener for dev fund donations | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190129-meeting-governance.md#52-decision-donation-addresses)
-|20190129 | Add Fund transparency report | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190129-meeting-governance.md#decision-fund-transparency-report)
-|20190122| Change pull request review process | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190122-meeting-development.md#81-decision-pull-request-reviews) |
-|20190122| Add issue reporting templates | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190122-meeting-development.md#decision-add-issue-reporting-templates) |
-|20190122| Define work approach for releases | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190122-meeting-development.md#decision-define-approach-for-releases)
-|20190117| Adopt Currency Symbol | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#102-currency-symbol) |
-|20190117| Adopt Currency Code | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#101-currency-code) |
-|20190117| Where/how to promote communities and events | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#decision-managing-chat-channels) |
-|20190117| Merge new design for grin-tech.org | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#decision-update-to-website-design) |
-|20190117| Fee for exchange integration support |[Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#decision-exchange-integration-support-rate) |
-|20190117| Review three price quotes for security audits, time for deciding on winning bid | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#decision-how-to-settle-on-auditor) |
-20190108 | Initial scope for v1.1.0 | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190108-meeting-development.md#5-post-mainnet-planning)
-20190108 | Test main net launch | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190108-meeting-development.md#45-mainnet-launch-dry-run)
-20190102 | Bikeshedding polls | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190103-meeting-governance.md#92-bikeshedding)
-20190103 | Genesis block message | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190103-meeting-governance.md#921-genesis-message)
-20190103 | Deadline for Risk brainstorm process | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190103-meeting-governance.md#decision-2)
+ID | Date | Decision | Reference |
+|---|:---|:---|:---|
+20 | 20190219 | Release week for v1.0.2 | [Meeting Note](notes/20190219-meeting-development.md#decision-v102) |
+19 | 20190212 | Firm to hire for security audit | [Meeting Note](notes/20190212-meeting-governance.md#decision-security-audit-firm) |
+18 | 20190205 | Handling unsafe http transactions | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190205-meeting-development.md#decision-approach-for-http-transactions-in-grin-wallet) |
+17 | 20190129 | StackExchange approach | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190129-meeting-governance.md#decision-stackexchange-approach) |
+16 | 20190129 | Run https listener for dev fund donations | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190129-meeting-governance.md#52-decision-donation-addresses)
+15 | 20190129 | Add Fund transparency report | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190129-meeting-governance.md#decision-fund-transparency-report)
+14 | 20190122| Change pull request review process | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190122-meeting-development.md#81-decision-pull-request-reviews) |
+13 | 20190122| Add issue reporting templates | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190122-meeting-development.md#decision-add-issue-reporting-templates) |
+12 | 20190122| Define work approach for releases | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190122-meeting-development.md#decision-define-approach-for-releases)
+11 | 20190117| Adopt Currency Symbol | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#102-currency-symbol) |
+10 | 20190117| Adopt Currency Code | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#101-currency-code) |
+9 | 20190117| Where/how to promote communities and events | [Meeting Note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#decision-managing-chat-channels) |
+8 | 20190117| Merge new design for grin-tech.org | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#decision-update-to-website-design) |
+7 | 20190117| Fee for exchange integration support |[Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#decision-exchange-integration-support-rate) |
+6 | 20190117| Review three price quotes for security audits, time for deciding on winning bid | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190117-meeting-governance.md#decision-how-to-settle-on-auditor) |
+5 | 20190108 | Initial scope for v1.1.0 | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190108-meeting-development.md#5-post-mainnet-planning)
+4 | 20190108 | Test main net launch | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190108-meeting-development.md#45-mainnet-launch-dry-run)
+3 |20190102 | Bikeshedding polls | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190103-meeting-governance.md#92-bikeshedding)
+2 | 20190103 | Genesis block message | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190103-meeting-governance.md#921-genesis-message)
+1 | 20190103 | Deadline for Risk brainstorm process | [Meeting note](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190103-meeting-governance.md#decision-2)

--- a/financials/donation_log.csv
+++ b/financials/donation_log.csv
@@ -1,0 +1,2 @@
+donation_id,date,donor,currency,amount,exchange_rate,USD_equivalent,to_address,tx_reference,comment
+1,20190301,Minerbabe,GRIN,2162.16,3.2,6919.04,https://donations.grin-tech.org,18f15e60-fa6c-400a-bad5-1821555839b5,Dev fee received by kbminer

--- a/financials/donation_log.csv
+++ b/financials/donation_log.csv
@@ -1,2 +1,0 @@
-donation_id,date,donor,currency,amount,exchange_rate,USD_equivalent,to_address,tx_reference,comment
-1,20190301,Minerbabe,GRIN,2162.16,3.2,6919.04,https://donations.grin-tech.org,18f15e60-fa6c-400a-bad5-1821555839b5,Dev fee received by kbminer

--- a/financials/income_log.csv
+++ b/financials/income_log.csv
@@ -1,0 +1,2 @@
+income_id,date,type,source,currency,amount,exchange_rate,USD_equivalent,to_address,tx_reference,comment
+1,20190301,donation,Minerbabe,GRIN,2162.16,3.2,6919.04,https://donations.grin-tech.org,18f15e60-fa6c-400a-bad5-1821555839b5,Dev fee received by kbminer

--- a/financials/spending_log.csv
+++ b/financials/spending_log.csv
@@ -1,0 +1,2 @@
+spend_id,date,spend_description,decision_log_id,currency,amount,exchange_rate,USD_equivalent,from_address,to_address,tx_reference,comment
+1,20190301,Coinspect audit fee,19,BTC,4.482,3882.66,17402.08,3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs,17Du5PQfcLq1yeV8yw512M5UnkeZvTwe7f,https://www.blockchain.com/btc/tx/022feacd15899425ee5a164f6e67a3f8701ce4fecbad8bf4532f2576f172a468,30% advance payment


### PR DESCRIPTION
This PR implements logs that will support [funding transparency reports](https://github.com/mimblewimble/grin-pm/blob/master/notes/20190129-meeting-governance.md#decision-fund-transparency-report).

Specifically, it:
1. Gives each decision log entry a unique ID (to make it easy to reference);
2. Adds a `financials/income_log.csv`, with the first entry being today's donation from Minerbabe;
3. Adds a `financials/spending_log.csv`, with the first entry being today's 30% advance to Coinspect for the security audits;

_edit: updating based on feedback below._