### PR TITLE
BlockCypher Discourse financing, Sparkpool Feb

### DIFF
--- a/financials/income_log.csv
+++ b/financials/income_log.csv
@@ -1,3 +1,5 @@
 income_id,date,type,source,currency,amount,exchange_rate,USD_equivalent,to_address,tx_reference,comment
 1,20190301,donation,Minerbabe,GRIN,2162.16,3.2,6919.04,https://donations.grin-tech.org,18f15e60-fa6c-400a-bad5-1821555839b5,Dev fee received by kbminer
 2,20190304,donation,BlockCypher,GRIN,1281.3,3.3,4228.29,https://donations.grin-tech.org,8df506ff-6058-4d74-8028-e5ba5f3f28df,Grinmint 0.5% dev fee
+3,20190303,donation,Sparkpool,GRIN,5500,3.63,20000.29,https://donations.grin-tech.org,817e0a69-5ab0-421f-afc3-406f61dd2bb4,Sparkpool fee
+4,20190304,donation,BlockCypher,USD,3600,1,3600,Discourse,-,BlockCypher financing last 6 months and next 2 years (so 30 months) of Discourse subscription (120 USD/month)


### PR DESCRIPTION
Adding 2 new lines to incomes:

1. BlockCypher is financing our Discourse instance for the past 6 months and the next 24 months. This comes from the proceeds of GrinconUS. This makes a lot of sense as this all comes in USD and Discourse requires USD. The total is 30 months at 120 USD per month.
2. Sparkpool contribution for February/March to a $20k equivalent in Grin.

Thanks to both for the continuing support!