### PR TITLE
Create payment address document

### DIFF
--- a/financials/addresses.md
+++ b/financials/addresses.md
@@ -1,0 +1,60 @@
+# Grin Project Payment Addresses <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc --> 
+- [About](#about)
+- [Verification](#verification)
+- [Contact](#contact)
+- [List of addresses](#list-of-addresses)
+  - [Grin General Fund](#grin-general-fund)
+    - [Grin](#grin)
+    - [Bitcoin](#bitcoin)
+      - [Segwit](#segwit)
+      - [Legacy](#legacy)
+    - [Ethereum](#ethereum)
+    - [Zcash](#zcash)
+
+## About
+This document is the only valid list of addresses for donations, sponsorships, or other forms of payments intended for the Grin project.
+
+## Verification
+This document should be hosted on the following address:
+`https://github.com/mimblewibmle/grin-pm/blob/master/financials/addresses.md`
+
+You can verify that any changes to the document have been made in commits signed with PGP keys by members of the grin core team.
+
+## Contact
+Any questions or concerns about authenticity can be raised publicly in the Grin community via [gitter]() or [keybase](), or in private over email through following the steps outlined in [Grin's security process](https://github.com/mimblewimble/grin/blob/master/SECURITY.md).  
+
+---
+
+## List of addresses
+
+### Grin General Fund
+
+#### Grin
+
+`https://council-donations.yeastplume.org`
+
+
+#### Bitcoin
+
+##### Segwit
+
+`3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs`
+
+https://blockchair.com/bitcoin/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs
+
+##### Legacy
+
+`bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65`
+
+https://blockchair.com/bitcoin/address/bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65
+
+#### Ethereum
+
+Currently unavailable.
+
+#### Zcash
+
+Currently unavailable.
+

--- a/financials/addresses.md
+++ b/financials/addresses.md
@@ -8,8 +8,8 @@
   - [Grin General Fund](#grin-general-fund)
     - [Grin](#grin)
     - [Bitcoin](#bitcoin)
-      - [Segwit](#segwit)
       - [Legacy](#legacy)
+      - [Segwit](#segwit)
     - [Ethereum](#ethereum)
     - [Zcash](#zcash)
 
@@ -38,13 +38,13 @@ Any questions or concerns about authenticity can be raised publicly in the Grin 
 
 #### Bitcoin
 
-##### Segwit
+##### Legacy
 
 `3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs`
 
 https://blockchair.com/bitcoin/address/3ChVP627KU5w4zu2rieFPF3wGXWQgmhvrs
 
-##### Legacy
+##### Segwit
 
 `bc1qdgs8vkpzr256qjlzlfht72z3mhcrdrt6wj2rfjw39j8us24gz8uq78qj65`
 

--- a/financials/addresses.md
+++ b/financials/addresses.md
@@ -23,7 +23,7 @@ This document should be hosted on the following address:
 You can verify that any changes to the document have been made in commits signed with PGP keys by members of the grin core team.
 
 ## Contact
-Any questions or concerns about authenticity can be raised publicly in the Grin community via [gitter]() or [keybase](), or in private over email through following the steps outlined in [Grin's security process](https://github.com/mimblewimble/grin/blob/master/SECURITY.md).  
+Any questions or concerns about authenticity can be raised publicly in the Grin community via [gitter](https://gitter.im/grin_community/Lobby) or [keybase](https://keybase.io/team/grincoin), or in private over email through following the steps outlined in [Grin's security process](https://github.com/mimblewimble/grin/blob/master/SECURITY.md).  
 
 ---
 


### PR DESCRIPTION
Partially addressing https://github.com/mimblewimble/site/issues/151, this creates a single source of truth for donation addresses. Once merged, I will link to this from the website and elsewhere. Given the sensitive nature, please review and approve the pull request. 