### PR TITLE
add links to the Grin wallet tx log

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A chronological list of decisions made by the Grin project, with references. Ava
 | [Addresses](financials/addresses.md) | The list of cryptocurrency addresses associated to the project. |
 | [Transparency reports](financials/reports/) | Financial transparency reports on a quarterly basis. |
 | [Financial logs](financials/) | Line by line details of income and spending. |
+| [Grin wallet transactions](financials/grin-wallet-txs.md) | Snapshot of the transaction log of the Grin donation wallet. |
 
 
 ## Meeting notes

--- a/financials/addresses.md
+++ b/financials/addresses.md
@@ -35,6 +35,7 @@ Any questions or concerns about authenticity can be raised publicly in the Grin 
 
 `https://council-donations.yeastplume.org`
 
+[Transaction log snapshot](grin-wallet-txs.md).
 
 #### Bitcoin
 


### PR DESCRIPTION
this PR adds links to the Grin wallet tx log on the readme page and in the addresses document.