### PR TITLE
update grin-wallet tx log, july 2020

### DIFF
--- a/financials/grin-wallet-txs.md
+++ b/financials/grin-wallet-txs.md
@@ -4,7 +4,7 @@ This is a snapshot of the `grin-wallet txs` command for `https://council-donatio
 
 Discrepancies between this log and the [income log](income_log.csv) and [spending log](spending_log.csv) can be corrected via pull requests.
 
-**Last update:** Jun 22 2020
+**Last update:** Jul 31 2020
 
 ## Command output
 ```


### PR DESCRIPTION
There's been no new donations to the grin wallet since last update